### PR TITLE
Configurable max rows per streaming request

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -264,7 +264,8 @@ public class BigQuerySinkTask extends SinkTask {
                 recordConverter);
           } else {
             TableWriter.Builder simpleTableWriterBuilder =
-                new TableWriter.Builder(bigQueryWriter, table, recordConverter);
+                new TableWriter.Builder(bigQueryWriter, table, recordConverter,
+                        config.getInt(BigQuerySinkConfig.BQ_STREAMING_MAX_ROWS_PER_REQUEST_CONFIG));
             if (upsertDelete) {
               simpleTableWriterBuilder.onFinish(rows ->
                   mergeBatches.onRowWrites(table.getBaseTableId(), rows));

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -93,6 +93,18 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "The interval, in seconds, in which to attempt to run GCS to BQ load jobs. Only relevant "
       + "if enableBatchLoad is configured.";
 
+  public static final String BQ_STREAMING_MAX_ROWS_PER_REQUEST_CONFIG =                     "bqStreamingMaxRowsPerRequest";
+  private static final ConfigDef.Type BQ_STREAMING_MAX_ROWS_PER_REQUEST_TYPE =              ConfigDef.Type.INT;
+  private static final Integer BQ_STREAMING_MAX_ROWS_PER_REQUEST_DEFAULT =                  50000;
+  private static final ConfigDef.Importance BQ_STREAMING_MAX_ROWS_PER_REQUEST_IMPORTANCE =  ConfigDef.Importance.LOW;
+  private static final String BQ_STREAMING_MAX_ROWS_PER_REQUEST_DOC =
+          "Due to BQ streaming put limitations, the max request size is 10MB. " +
+                  "Hence, considering that in average 1 record takes at least 20 bytes, " +
+                  "if we have big batches (e.g. 500000) we might need to run against BigQuery multiple requests " +
+                  "that would return a `Request Too Large` before finding the right size. " +
+                  "This config allows starting from a lower value altogether and reduce the amount of failed requests. " +
+                  "Only works with simple TableWriter (no GCS)";
+
   public static final String GCS_BUCKET_NAME_CONFIG =                     "gcsBucketName";
   private static final ConfigDef.Type GCS_BUCKET_NAME_TYPE =              ConfigDef.Type.STRING;
   private static final Object GCS_BUCKET_NAME_DEFAULT =                   "";
@@ -518,6 +530,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             GCS_FOLDER_NAME_DEFAULT,
             GCS_FOLDER_NAME_IMPORTANCE,
             GCS_FOLDER_NAME_DOC
+        ).define(
+            BQ_STREAMING_MAX_ROWS_PER_REQUEST_CONFIG,
+            BQ_STREAMING_MAX_ROWS_PER_REQUEST_TYPE,
+            BQ_STREAMING_MAX_ROWS_PER_REQUEST_DEFAULT,
+            BQ_STREAMING_MAX_ROWS_PER_REQUEST_IMPORTANCE,
+            BQ_STREAMING_MAX_ROWS_PER_REQUEST_DOC
         ).define(
             PROJECT_CONFIG,
             PROJECT_TYPE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -55,28 +55,32 @@ public class TableWriter implements Runnable {
   private final PartitionedTableId table;
   private final SortedMap<SinkRecord, RowToInsert> rows;
   private final Consumer<Collection<RowToInsert>> onFinish;
+  private int bqStreamingMaxRowsPerRequest;
 
   /**
-   * @param writer the {@link BigQueryWriter} to use.
-   * @param table the BigQuery table to write to.
-   * @param rows the rows to write.
-   * @param onFinish a callback to invoke after all rows have been written successfully, which is
-   *                 called with all the rows written by the writer
+   * @param writer                the {@link BigQueryWriter} to use.
+   * @param table                 the BigQuery table to write to.
+   * @param rows                  the rows to write.
+   * @param onFinish              a callback to invoke after all rows have been written successfully, which is
+   *                              called with all the rows written by the writer
+   * @param bqStreamingMaxRowsPerRequest max rows per InsertAll request
    */
   public TableWriter(BigQueryWriter writer,
                      PartitionedTableId table,
                      SortedMap<SinkRecord, RowToInsert> rows,
-                     Consumer<Collection<RowToInsert>> onFinish) {
+                     Consumer<Collection<RowToInsert>> onFinish,
+                     int bqStreamingMaxRowsPerRequest) {
     this.writer = writer;
     this.table = table;
     this.rows = rows;
     this.onFinish = onFinish;
+    this.bqStreamingMaxRowsPerRequest = bqStreamingMaxRowsPerRequest;
   }
 
   @Override
   public void run() {
     int currentIndex = 0;
-    int currentBatchSize = rows.size();
+    int currentBatchSize = Math.min(bqStreamingMaxRowsPerRequest, rows.size());
     int successCount = 0;
     int failureCount = 0;
 
@@ -170,6 +174,7 @@ public class TableWriter implements Runnable {
   public static class Builder implements TableWriterBuilder {
     private final BigQueryWriter writer;
     private final PartitionedTableId table;
+    private final int bqStreamingMaxRowsPerRequest;
 
     private SortedMap<SinkRecord, RowToInsert> rows;
     private SinkRecordConverter recordConverter;
@@ -180,9 +185,11 @@ public class TableWriter implements Runnable {
      * @param table the BigQuery table to write to.
      * @param recordConverter the record converter used to convert records to rows
      */
-    public Builder(BigQueryWriter writer, PartitionedTableId table, SinkRecordConverter recordConverter) {
+    public Builder(BigQueryWriter writer, PartitionedTableId table, SinkRecordConverter recordConverter,
+                   int bqStreamingMaxRowsPerRequest) {
       this.writer = writer;
       this.table = table;
+      this.bqStreamingMaxRowsPerRequest = bqStreamingMaxRowsPerRequest;
 
       this.rows = new TreeMap<>(Comparator.comparing(SinkRecord::kafkaPartition)
               .thenComparing(SinkRecord::kafkaOffset));
@@ -211,7 +218,7 @@ public class TableWriter implements Runnable {
 
     @Override
     public TableWriter build() {
-      return new TableWriter(writer, table, rows, onFinish != null ? onFinish : n -> { });
+      return new TableWriter(writer, table, rows, onFinish != null ? onFinish : n -> { }, bqStreamingMaxRowsPerRequest);
     }
   }
 }


### PR DESCRIPTION
Due to BQ streaming put limitations, the max request size is 10MB. 

Hence, considering that in average 1 record takes at least 20 bytes, if we have big batches (e.g. 500000) we might need to run against BigQuery multiple requests that would return a `Request Too Large` before finding the right size. 

This config allows starting from a lower value altogether and reduce the amount of failed requests. Only works with simple TableWriter (no GCS)